### PR TITLE
Replace jack with ecj and dx

### DIFF
--- a/buildapk
+++ b/buildapk
@@ -81,13 +81,11 @@ do_build() {
     echo "done"
      
     echo -n "Compiling and dexing source files..."
-    dir="$(dirname "$(realpath "$OUTPUT_DIR/build")")"
-    name="$(basename "$OUTPUT_DIR/build" .java)"
-    tempdir="$dir/tmp$RANDOM"
+    TEMP_DIR="$dir/tmp$RANDOM"
     
-    ecj -sourcepath $dir $dir/${name}.java -d $tempdir 
+    ecj -sourcepath $OUTPUT_DIR $OUTPUT_DIR/build -d $TEMP_DIR
     dx --dex --output=$OUTPUT_DIR/build *
-    rm -rf $tempdir
+    rm -rf $TEMP_DIR
     echo "done"
     
     echo -n "Creating apk and adding dexed classes..."

--- a/buildapk
+++ b/buildapk
@@ -81,11 +81,13 @@ do_build() {
     echo "done"
      
     echo -n "Compiling and dexing source files..."
-    TEMP_DIR="$dir/tmp$RANDOM"
+    dir="$(dirname "$(realpath "$OUTPUT_DIR/build")")"
+    name="$(basename "$OUTPUT_DIR/build" .java)"
+    tempdir="$dir/tmp$RANDOM"
     
-    ecj -sourcepath $OUTPUT_DIR $OUTPUT_DIR/build -d $TEMP_DIR
+    ecj -sourcepath $dir $dir/${name}.java -d $tempdir 
     dx --dex --output=$OUTPUT_DIR/build *
-    rm -rf $TEMP_DIR
+    rm -rf $tempdir
     echo "done"
     
     echo -n "Creating apk and adding dexed classes..."

--- a/buildapk
+++ b/buildapk
@@ -48,7 +48,8 @@ do_build() {
     fi
     
     type aapt > /dev/null || { echo >&2 "Error: Please install 'aapt'. Aborting..."; exit 1; }
-    type jack > /dev/null || { echo >&2 "Error: Please install 'jack'. Aborting..."; exit 1; }
+    type ecj > /dev/null || { echo >&2 "Error: Please install 'ecj'. Aborting..."; exit 1; }
+    type dx > /dev/null || { echo >&2 "Error: Please install 'dx'. Aborting..."; exit 1; }
     type apksigner > /dev/null || { echo >&2 "Error: Please install 'apksigner'. Aborting..."; exit 1; }
     
     if [ ! -d $OUTPUT_DIR ]; then
@@ -79,8 +80,14 @@ do_build() {
     aapt package -m -J $OUTPUT_DIR/build -M ./AndroidManifest.xml -S res -I $ANDROID_JAR
     echo "done"
      
-    echo -n "Compilng and dexing source files..."
-    jack --output-dex $OUTPUT_DIR/build
+    echo -n "Compiling and dexing source files..."
+    dir="$(dirname "$(realpath "$OUTPUT_DIR/build")")"
+    name="$(basename "$OUTPUT_DIR/build" .java)"
+    tempdir="$dir/tmp$RANDOM"
+    
+    ecj -sourcepath $dir $dir/${name}.java -d $tempdir 
+    dx --dex --output=$OUTPUT_DIR/build *
+    rm -rf $tempdir
     echo "done"
     
     echo -n "Creating apk and adding dexed classes..."


### PR DESCRIPTION
As [`jack` is deprecated](https://android-developers.googleblog.com/2017/03/future-of-java-8-language-feature.html), Termux instead uses [`ecj`](https://github.com/termux/termux-packages/tree/master/packages/ecj) for compilation and [`dx`](https://github.com/termux/termux-packages/tree/master/packages/dx) to convert class files to dex format for usage on Android.