### PR TITLE
Replace jack with ecj and dx

### DIFF
--- a/buildapk
+++ b/buildapk
@@ -48,7 +48,8 @@ do_build() {
     fi
     
     type aapt > /dev/null || { echo >&2 "Error: Please install 'aapt'. Aborting..."; exit 1; }
-    type jack > /dev/null || { echo >&2 "Error: Please install 'jack'. Aborting..."; exit 1; }
+    type ecj > /dev/null || { echo >&2 "Error: Please install 'ecj'. Aborting..."; exit 1; }
+    type dx > /dev/null || { echo >&2 "Error: Please install 'dx'. Aborting..."; exit 1; }
     type apksigner > /dev/null || { echo >&2 "Error: Please install 'apksigner'. Aborting..."; exit 1; }
     
     if [ ! -d $OUTPUT_DIR ]; then
@@ -78,9 +79,15 @@ do_build() {
     fi
     aapt package -m -J $OUTPUT_DIR/build -M ./AndroidManifest.xml -S res -I $ANDROID_JAR
     echo "done"
-     
-    echo -n "Compilng and dexing source files..."
-    jack --output-dex $OUTPUT_DIR/build
+    
+    echo -n "Compiling and dexing source files..."
+    dir="$(dirname "$(realpath "$OUTPUT_DIR/build")")"
+	name="$(basename "$dir/*" .java)"
+	tempdir="$dir/tmp$RANDOM"
+	ecj -sourcepath "$dir" "$dir/${name}.java" -d "$tempdir"
+	cd "$tempdir"
+	dx --dex --output="$dir/${name}.dex" *
+	rm -rf "$tempdir"
     echo "done"
     
     echo -n "Creating apk and adding dexed classes..."


### PR DESCRIPTION
As [`jack` is deprecated](https://android-developers.googleblog.com/2017/03/future-of-java-8-language-feature.html), Termux instead uses [`ecj`](https://github.com/termux/termux-packages/tree/master/packages/ecj) for compilation and [`dx`](https://github.com/termux/termux-packages/tree/master/packages/dx) to convert class files to dex format for usage on Android.